### PR TITLE
OPS-3227 - right_chimp now builds for docker image using ruby 2.3.x v…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@
 # Built via: docker build -t mastamark/right_chimp:latest .
 ###
 
-FROM rightscale/ops_ruby22x_build
+FROM rightscale/ops_ruby23x_build
 MAINTAINER mastamark+github@gmail.com
 WORKDIR /srv
 ADD right_chimp.sh /srv/


### PR DESCRIPTION

![ubuntu-ruby-2-3](https://cloud.githubusercontent.com/assets/812958/17686223/9bf48c6e-631f-11e6-8508-0b21f4824b13.png)
…s. 2.2.x