### PR TITLE
OPS-3261 skip interactive prompt in automation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -176,3 +176,7 @@ Version 2.1.20
 Version 2.1.21
 --------------
 * Bugfix: Pull the correct path whenever loading up the erb template in webui.
+
+Version 2.1.22
+--------------
+* Bugfix: use 'pause' behaviour if there are no contents in stdin

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    right_chimp (2.1.21)
+    right_chimp (2.1.22)
       highline (~> 1.7.2)
       nokogiri (~> 1.6.7.1)
       progressbar (~> 0.11.0)

--- a/lib/right_chimp/Chimp.rb
+++ b/lib/right_chimp/Chimp.rb
@@ -1011,6 +1011,15 @@ module Chimp
         puts "(A)bort chimp run"
         puts "(I)gnore errors and continue"
         command = gets()
+        if command.nil?
+          #
+          # if command is nil, stdin is closed or its source ended
+          #  probably because we are in an automated environment,
+          #  then we pause like in '--no-prompt' scenario
+          #
+          puts 'Warning! stdin empty, using pause behaviour, use --no-prompt to avoid this message'
+          return 'pause'
+        end
 
         if command =~ /^a/i
           puts "Aborting!"

--- a/lib/right_chimp/version.rb
+++ b/lib/right_chimp/version.rb
@@ -1,3 +1,3 @@
 module Chimp
-  VERSION = "2.1.21"
+  VERSION = "2.1.22"
 end


### PR DESCRIPTION
 if gets return nil, it means stdin is closed or its source ended (if we were piping from another process or file). This means we are probably in an automated environment, so we pause like we do with "--no-prompt" switch