### PR TITLE
updating_instructions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -38,3 +38,4 @@ a list of all the operational servers in your account:
     :user: <email>
     :refresh_token: <refresh_token>
     :api_url: https://us-3.rightscale.com/api/acct/<account>
+    :account: <account>

--- a/INSTALL
+++ b/INSTALL
@@ -37,5 +37,4 @@ a list of all the operational servers in your account:
     - ~/.ssh/id_rsa
     :user: <email>
     :refresh_token: <refresh_token>
-    :api_url: https://us-3.rightscale.com
-    :account: <account>
+    :api_url: https://us-3.rightscale.com/api/acct/<account>


### PR DESCRIPTION
I found that this does not work (right-api-onesix reports Mar 20 15:26:48 fe4a64109b0f right_api_16[118]: shard3/right-api-onesix: Request failed validation: ["Error loading attribute $.headers.key(\"X-Account\") of type Attributor::Integer from value \"us-3.rightscale.com\"\ninvalid value for Integer(): \"us-3.rightscale.com\""]):

:ssh_keys:
- ~/.ssh/id_rsa
:user: greg.coit@rightscale.com
:refresh_token: REDACTED
:api_url: https://us-3.rightscale.com
:account: 9202

But this does:
:ssh_keys:
- ~/.ssh/id_rsa
:user: greg.coit@rightscale.com
:refresh_token: REDACTED
:api_url: https://us-3.rightscale.com/ap/acct/9202

So this PR is to update the instructions
